### PR TITLE
run locally installed gulp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "ToT",


### PR DESCRIPTION
npm will use gulp from node_modules folder, instead of globally installed. so, users with another globally installed gulp version (for example, 3.9.1) will be able to run scripts with command `npm start`